### PR TITLE
Fix unsigned vs. signed problem

### DIFF
--- a/DiscImageChef.Devices/Device/Constructor.cs
+++ b/DiscImageChef.Devices/Device/Constructor.cs
@@ -154,10 +154,10 @@ namespace DiscImageChef.Devices
                     descriptor.DeviceTypeModifier = descriptorB[9];
                     descriptor.RemovableMedia = descriptorB[10] > 0;
                     descriptor.CommandQueueing = descriptorB[11] > 0;
-                    descriptor.VendorIdOffset = BitConverter.ToUInt32(descriptorB, 12);
-                    descriptor.ProductIdOffset = BitConverter.ToUInt32(descriptorB, 16);
-                    descriptor.ProductRevisionOffset = BitConverter.ToUInt32(descriptorB, 20);
-                    descriptor.SerialNumberOffset = BitConverter.ToUInt32(descriptorB, 24);
+                    descriptor.VendorIdOffset = BitConverter.ToInt32(descriptorB, 12);
+                    descriptor.ProductIdOffset = BitConverter.ToInt32(descriptorB, 16);
+                    descriptor.ProductRevisionOffset = BitConverter.ToInt32(descriptorB, 20);
+                    descriptor.SerialNumberOffset = BitConverter.ToInt32(descriptorB, 24);
                     descriptor.BusType = (Windows.StorageBusType)BitConverter.ToUInt32(descriptorB, 28);
                     descriptor.RawPropertiesLength = BitConverter.ToUInt32(descriptorB, 32);
                     descriptor.RawDeviceProperties = new byte[descriptor.RawPropertiesLength];

--- a/DiscImageChef.Devices/Windows/ListDevices.cs
+++ b/DiscImageChef.Devices/Windows/ListDevices.cs
@@ -114,10 +114,10 @@ namespace DiscImageChef.Devices.Windows
                 descriptor.DeviceTypeModifier = descriptorB[9];
                 descriptor.RemovableMedia = BitConverter.ToBoolean(descriptorB, 10);
                 descriptor.CommandQueueing = BitConverter.ToBoolean(descriptorB, 11);
-                descriptor.VendorIdOffset = BitConverter.ToUInt32(descriptorB, 12);
-                descriptor.ProductIdOffset = BitConverter.ToUInt32(descriptorB, 16);
-                descriptor.ProductRevisionOffset = BitConverter.ToUInt32(descriptorB, 20);
-                descriptor.SerialNumberOffset = BitConverter.ToUInt32(descriptorB, 24);
+                descriptor.VendorIdOffset = BitConverter.ToInt32(descriptorB, 12);
+                descriptor.ProductIdOffset = BitConverter.ToInt32(descriptorB, 16);
+                descriptor.ProductRevisionOffset = BitConverter.ToInt32(descriptorB, 20);
+                descriptor.SerialNumberOffset = BitConverter.ToInt32(descriptorB, 24);
                 descriptor.BusType = (StorageBusType)BitConverter.ToUInt32(descriptorB, 28);
                 descriptor.RawPropertiesLength = BitConverter.ToUInt32(descriptorB, 32);
 

--- a/DiscImageChef.Devices/Windows/Structs.cs
+++ b/DiscImageChef.Devices/Windows/Structs.cs
@@ -166,10 +166,10 @@ namespace DiscImageChef.Devices.Windows
         public byte DeviceTypeModifier;
         [MarshalAs(UnmanagedType.U1)] public bool RemovableMedia;
         [MarshalAs(UnmanagedType.U1)] public bool CommandQueueing;
-        public uint VendorIdOffset;
-        public uint ProductIdOffset;
-        public uint ProductRevisionOffset;
-        public uint SerialNumberOffset;
+        public int VendorIdOffset;
+        public int ProductIdOffset;
+        public int ProductRevisionOffset;
+        public int SerialNumberOffset;
         public StorageBusType BusType;
         public uint RawPropertiesLength;
         public byte[] RawDeviceProperties;


### PR DESCRIPTION
Fix [crash](https://pastebin.com/TZNVX3dw) on Windows when using `list-devices`.

Problem is that the fields in the `StorageDeviceDescriptor` are uint, then checked against `> 0`, then cast to int, which crashes the string indexing in `CToString(...)`