### PR TITLE
Add workaround to correctly display device serials

### DIFF
--- a/DiscImageChef.Devices/Windows/ListDevices.cs
+++ b/DiscImageChef.Devices/Windows/ListDevices.cs
@@ -46,7 +46,7 @@ namespace DiscImageChef.Devices.Windows
             StringBuilder result = new StringBuilder();
             const string hextable = "0123456789abcdef";
 
-            for (int i = 0; i < hex.Length / 2; i++)
+            for(int i = 0; i < hex.Length / 2; i++)
             {
                 result.Append((char)(16 * hextable.IndexOf(hex[2 * i]) + hextable.IndexOf(hex[2 * i + 1])));
             }
@@ -143,14 +143,14 @@ namespace DiscImageChef.Devices.Windows
                     info.Model =
                         StringHandlers.CToString(descriptorB, Encoding.ASCII, start: (int)descriptor.ProductIdOffset);
                 // TODO: Get serial number of SCSI and USB devices, probably also FireWire (untested)
-                if (descriptor.SerialNumberOffset > 0)
+                if(descriptor.SerialNumberOffset > 0)
                 {
                     info.Serial =
                         StringHandlers.CToString(descriptorB, Encoding.ASCII,
                                                  start: (int)descriptor.SerialNumberOffset);
 
                     // fix any serial numbers that are returned as hex-strings
-                    if (Array.TrueForAll(info.Serial.ToCharArray(), (char c) => "0123456789abcdef".IndexOf(c) >= 0) 
+                    if(Array.TrueForAll(info.Serial.ToCharArray(), (char c) => "0123456789abcdef".IndexOf(c) >= 0) 
                         && (info.Serial.Length == 40))
                     {
                         info.Serial = HexStringToString(info.Serial).Trim();


### PR DESCRIPTION
Some devices on windows (especially, apparently, SATA devices behind a bridge chip) report their serial number as a string of hex bytes instead of ASCII.

This patch tries to detect that and transparently work around it.