### PR TITLE
Fix reading sector tag

### DIFF
--- a/Aaru.Images/AaruFormat/Read.cs
+++ b/Aaru.Images/AaruFormat/Read.cs
@@ -2009,8 +2009,8 @@ public sealed partial class AaruFormat
         }
 
         for(int i = 0; i < length; i++)
-            Array.Copy(dataSource, (long)(sectorAddress * (sectorOffset + sectorSize + sectorSkip)), buffer,
-                       i * sectorSize, sectorSize);
+            Array.Copy(dataSource, (long)((sectorAddress * (sectorOffset + sectorSize + sectorSkip)) + sectorOffset),
+                       buffer, i * sectorSize, sectorSize);
 
         return ErrorNumber.NoError;
     }


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please check this *carefully*, but I think this bugfix is correct.

Previous code read at wrong offset when reading a sector tag from aaruf from a buffer storing multiple tags in sequence, like the CPR_MAI on DVDs and CD subchannels.

As far as I know nothing was actually affected since subchannels on CDs were always read in `ReadSectorLong` and no other format handled the CPR_MAI. CD subchannels *could* be affected though.