### PR TITLE
Check title keys resume for null when not a DVD Video

### DIFF
--- a/Aaru.Core/Devices/Dumping/Sbc/Cache.cs
+++ b/Aaru.Core/Devices/Dumping/Sbc/Cache.cs
@@ -131,14 +131,14 @@ partial class Dump
                             0, 0, 0, 0, 0
                         }, i + j, SectorTagType.DvdTitleKeyDecrypted);
 
-                        _resume.MissingTitleKeys.Remove(i + j);
+                        _resume.MissingTitleKeys?.Remove(i + j);
 
                         continue;
                     }
 
                     CSS.DecryptTitleKey(discKey, key, out tmpBuf);
                     outputFormat.WriteSectorTag(tmpBuf, i + j, SectorTagType.DvdTitleKeyDecrypted);
-                    _resume.MissingTitleKeys.Remove(i     + j);
+                    _resume.MissingTitleKeys?.Remove(i    + j);
 
                     if(_storeEncrypted)
                         continue;


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)

Dumping raw would fail if not a DVD Video disc since it wouldn't have a title key resume list.