### PR TITLE
Make Kreon SCSI CDB10 for libata

### DIFF
--- a/Aaru.Devices/Device/ScsiCommands/Kreon.cs
+++ b/Aaru.Devices/Device/ScsiCommands/Kreon.cs
@@ -45,7 +45,7 @@ public partial class Device
     public bool KreonDeprecatedUnlock(out byte[] senseBuffer, uint timeout, out double duration)
     {
         senseBuffer = new byte[64];
-        var    cdb    = new byte[6];
+        var    cdb    = new byte[10];
         byte[] buffer = [];
 
         cdb[0] = (byte)ScsiCommands.KreonCommand;
@@ -101,7 +101,7 @@ public partial class Device
     public bool KreonSetLockState(out byte[] senseBuffer, KreonLockStates state, uint timeout, out double duration)
     {
         senseBuffer = new byte[64];
-        var    cdb    = new byte[6];
+        var    cdb    = new byte[10];
         byte[] buffer = [];
 
         cdb[0] = (byte)ScsiCommands.KreonCommand;
@@ -135,7 +135,7 @@ public partial class Device
                                     out double duration)
     {
         senseBuffer = new byte[64];
-        var cdb    = new byte[6];
+        var cdb    = new byte[10];
         var buffer = new byte[26];
         features = 0;
 


### PR DESCRIPTION
Simple bug fix
Fixes #850 

### Summary
This change turns the Kreon commands in Aaru into CDB10, which fixes dumping with SATA connections (`libata`) on Linux. It may fix MacOS dumps as well, however Mac has never been tested to be working or not working Windows doesn't do minimum CDB command size checks, hence why Windows dumps worked in the past, and this change does not break Windows dumps.

### Details
Kreon SCSI commands (vendor specific `0xFF`) are currently CDB6 (6-long CDB command) in Aaru.
Linux's `libata` expects a minimum of 10-long CDB command: https://github.com/torvalds/linux/blob/master/drivers/ata/libata-scsi.c#L4199
As a result, Aaru sends the Kreon lock state command, which returns sense data that looks like no error has occurred, so the dump continues. However, `libata` never sent the command to the driver, so the drive does not lock/unlock, and the wrong sectors are dumped.

### Testing
This PR follows work done by @tbejos to support Kreon dumping in redumper.
While it hasn't been tested in aaru, DIC and Redumper have both had this minor change and have been tested in Linux and Windows, so it follows that this change is required for Aaru too.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.