### PR TITLE
Fix regression in the publishing pipeline for v5.4

### DIFF
--- a/Aaru/Aaru.csproj
+++ b/Aaru/Aaru.csproj
@@ -19,6 +19,7 @@
     <Title>Aaru</Title>
     <ApplicationVersion>$(Version)</ApplicationVersion>
     <RuntimeIdentifiers>linux-arm64;linux-arm;linux-x64;osx-x64;win-arm64;win-x64;win-x86</RuntimeIdentifiers>
+    <PublishSelfContained>true</PublishSelfContained>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <LangVersion>12</LangVersion>
   </PropertyGroup>

--- a/Aaru/Aaru.csproj
+++ b/Aaru/Aaru.csproj
@@ -20,6 +20,7 @@
     <ApplicationVersion>$(Version)</ApplicationVersion>
     <RuntimeIdentifiers>linux-arm64;linux-arm;linux-x64;osx-x64;win-arm64;win-x64;win-x86</RuntimeIdentifiers>
     <PublishSelfContained>true</PublishSelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <LangVersion>12</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Resolves https://github.com/aaru-dps/Aaru/issues/872.

Before target framework moniker (TFM) net8.0 using a runtime ID automatically
implied a self-contained build. Starting with TFM net8.0 the default changed and
the self-contained property now has to be explicitly requested.

The change from the older TFM to net8.0 during the 5.4 releases therefore
caused the previous standalone executables to be built as runtime dependent
executables. By explicitly requesting a self-contained executable, everything goes
back to the time-honored way (and the way things currently are in the `devel`
branch.)

I also checked the `devel` branch but these changes have already been applied there in August.
Take a look at the heading **Suggested changes for the devel branch** below for some further suggestions.

See:
https://github.com/dotnet/sdk/pull/30038
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tested by running `build.sh` with and without the patch applied. See https://github.com/aaru-dps/Aaru/issues/872 for the faulty output.
The expected output with the patches applied:
```
Required command was not provided.

aaru:
  aaru 5.4.1+d7153637.d7153637f82821ce5b6835ecf1dde6f402b95bdd Copyright © 2011-2025 Natalia
  Portillo

Usage:
  aaru [options] [command]

Options:
  -v, --verbose     Shows verbose output.
  -d, --debug       Shows debug output from plugins.
  --pause           Pauses before exiting.
  --version         Show version information
  -?, -h, --help    Show help and usage information

Commands:
  database, db          Commands to manage the device and statistics database
  dev, device           Commands that talks to devices
  fi, filesystem, fs    Commands to manage filesystems
  i, image              Commands to manage images
  m, media              Commands to manage media inserted in devices
  configure             Configures user settings and statistics.
  formats               Lists all supported disc images, partition schemes and file systems.
  list-encodings        Lists all supported text encodings and code pages.
  list-namespaces       Lists all namespaces supported by read-only filesystems.
  remote <host>         Tests connection to a Aaru Remote Server.
```

## Suggested changes for the `devel` branch
Some remarks regarding `devel/Aaru/Aaru.csproj`: `SelfContained` should most likely be `PublishSelfContained` (see https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#publishselfcontained)
Setting `PublishReadyToRun` and `PublishTrimmed` might also be worth considering, since the startup time is comparatively high for me.