### PR TITLE
Switch decoded bit for disk structure

### DIFF
--- a/Aaru.Decoders/DVD/PFI.cs
+++ b/Aaru.Decoders/DVD/PFI.cs
@@ -813,11 +813,11 @@ public static class PFI
         switch(decoded.TrackPath)
         {
             case true when decoded.Layers == 1:
-                sb.AppendLine(Localization.Layers_are_in_parallel_track_path);
+                sb.AppendLine(Localization.Layers_are_in_opposite_track_path);
 
                 break;
             case false when decoded.Layers == 1:
-                sb.AppendLine(Localization.Layers_are_in_opposite_track_path);
+                sb.AppendLine(Localization.Layers_are_in_parallel_track_path);
 
                 break;
         }

--- a/Aaru.Decoders/DVD/PFI.cs
+++ b/Aaru.Decoders/DVD/PFI.cs
@@ -101,8 +101,8 @@ public static class PFI
         pfi.MaximumRate   =  (MaximumRateField)(response[5] & 0x0F);
         pfi.Reserved3     |= (response[6]                   & 0x80) == 0x80;
         pfi.Layers        =  (byte)((response[6] & 0x60) >> 5);
-        pfi.TrackPath     |= (response[6]                     & 0x08) == 0x08;
-        pfi.LayerType     =  (LayerTypeFieldMask)(response[6] & 0x07);
+        pfi.TrackPath     |= (response[6]                     & 0x10) == 0x10;
+        pfi.LayerType     =  (LayerTypeFieldMask)(response[6] & 0x0F);
         pfi.LinearDensity =  (LinearDensityField)((response[7] & 0xF0) >> 4);
         pfi.TrackDensity  =  (TrackDensityField)(response[7] & 0x0F);
 


### PR DESCRIPTION
I think this is correct. ECMA-267 says

Bit b4 shall specify the track path
if set to ZERO, it specifies PTP on DL disks or a SL disk
if set to ONE, it specifies OTP on DL disks

so unless there is a flip of the in the decoder, true should be OTP.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.