### PR TITLE
Read PTP discs with 3c

### DIFF
--- a/Aaru.Core/Devices/Dumping/Sbc/Dump.cs
+++ b/Aaru.Core/Devices/Dumping/Sbc/Dump.cs
@@ -322,8 +322,8 @@ partial class Dump
                 PFI.PhysicalFormatInformation? decodedPfi = PFI.Decode(pfi, dskType);
 
                 scsiReader.layerbreak = decodedPfi?.Layer0EndPSN ?? 0;
+                if(scsiReader.layerbreak == 0) scsiReader.layerbreak = decodedPfi?.DataAreaEndPSN ?? 0;
                 scsiReader.otp        = decodedPfi?.TrackPath ?? false;
-                if(!scsiReader.otp) scsiReader.layerbreak = decodedPfi?.DataAreaEndPSN ?? 0;
 
                 if(scsiReader.HldtstReadRaw) blocksToRead = 1;
                 if(scsiReader.OmniDriveReadRaw) blocksToRead = 31;

--- a/Aaru.Core/Devices/Dumping/Sbc/Dump.cs
+++ b/Aaru.Core/Devices/Dumping/Sbc/Dump.cs
@@ -322,7 +322,8 @@ partial class Dump
                 PFI.PhysicalFormatInformation? decodedPfi = PFI.Decode(pfi, dskType);
 
                 scsiReader.layerbreak = decodedPfi?.Layer0EndPSN ?? 0;
-                scsiReader.otp        = decodedPfi is { Layers: 1, TrackPath: false };
+                scsiReader.otp        = decodedPfi?.TrackPath ?? false;
+                if(!scsiReader.otp) scsiReader.layerbreak = decodedPfi?.DataAreaEndPSN ?? 0;
 
                 if(scsiReader.HldtstReadRaw) blocksToRead = 1;
                 if(scsiReader.OmniDriveReadRaw) blocksToRead = 31;

--- a/Aaru.Decoders/DVD/PFI.cs
+++ b/Aaru.Decoders/DVD/PFI.cs
@@ -812,12 +812,12 @@ public static class PFI
 
         switch(decoded.TrackPath)
         {
-            case true when decoded.Layers == 1:
-                sb.AppendLine(Localization.Layers_are_in_parallel_track_path);
-
-                break;
             case false when decoded.Layers == 1:
                 sb.AppendLine(Localization.Layers_are_in_opposite_track_path);
+
+                break;
+            case true when decoded.Layers == 1:
+                sb.AppendLine(Localization.Layers_are_in_parallel_track_path);
 
                 break;
         }

--- a/Aaru.Decoders/DVD/PFI.cs
+++ b/Aaru.Decoders/DVD/PFI.cs
@@ -812,12 +812,12 @@ public static class PFI
 
         switch(decoded.TrackPath)
         {
-            case false when decoded.Layers == 1:
-                sb.AppendLine(Localization.Layers_are_in_opposite_track_path);
-
-                break;
             case true when decoded.Layers == 1:
                 sb.AppendLine(Localization.Layers_are_in_parallel_track_path);
+
+                break;
+            case false when decoded.Layers == 1:
+                sb.AppendLine(Localization.Layers_are_in_opposite_track_path);
 
                 break;
         }

--- a/Aaru.Devices/Device/ScsiCommands/ReadBuffer.cs
+++ b/Aaru.Devices/Device/ScsiCommands/ReadBuffer.cs
@@ -119,7 +119,7 @@ public partial class Device
             }
             else
             {
-                if(!IsCorrectSlPsn(sectorNumber, (ulong)(firstLba + i))) return false;
+                if(!IsCorrectDlPtpPsn(sectorNumber, (ulong)(firstLba + i), layer, layerbreak)) return false;
             }
         }
 
@@ -144,9 +144,9 @@ public partial class Device
     /// <returns><c>false</c> if the sector is not matching expected value, else <c>true</c></returns>
     static bool IsCorrectDlPtpPsn(uint sectorNumber, ulong lba, byte layer, uint layerbreak)
     {
-        if(layer != 1) return IsCorrectSlPsn(sectorNumber, lba);
+        if(layer == 0) return IsCorrectSlPsn(sectorNumber, lba);
 
-        return sectorNumber == lba - layerbreak + 0x30000;
+        return sectorNumber == lba + 0x30000 - (layerbreak + 1 - 0x30000);
     }
 
     /// <summary>
@@ -258,10 +258,10 @@ public partial class Device
             if(!sense && buffer != null && buffer.Length >= 2236 * 3)
             {
                 // Validate that the data starts with the expected DVD sector header pattern
-                if(buffer.Length >= 3 &&
-                   buffer[0] == 0x00 &&
+                if(buffer.Length >= 4 &&
                    buffer[1] == 0x03 &&
-                   buffer[2] == 0x00)
+                   buffer[2] == 0x00 &&
+                   buffer[3] == 0x00)
                 {
                     AaruLogging.Debug(SCSI_MODULE_NAME, "ReadBuffer 3C variant {0:x2}{1:x2} detected", variant.mode,
                                       variant.bufferId);
@@ -308,12 +308,12 @@ public partial class Device
             return 0; // Detection failed
         }
 
-        // Search for pattern 00 03 00 starting from beginning
+        // Search for pattern 03 00 00 starting from beginning + 1 byte
         // Find first occurrence
         int firstOffset = -1;
         for(int i = 0; i < buffer.Length - 3; i++)
         {
-            if(buffer[i] == 0x00 && buffer[i + 1] == 0x03 && buffer[i + 2] == 0x00)
+            if(buffer[i + 1] == 0x03 && buffer[i + 2] == 0x00 && buffer[i + 3] == 0x00)
             {
                 firstOffset = i;
                 break;
@@ -332,7 +332,7 @@ public partial class Device
         int secondOffset = -1;
         for(int i = firstOffset + 2064; i < Math.Min(firstOffset + 2500, buffer.Length - 3); i++)
         {
-            if(buffer[i] == 0x00 && buffer[i + 1] == 0x03 && buffer[i + 2] == 0x00)
+            if(buffer[i + 1] == 0x03 && buffer[i + 2] == 0x00 && buffer[i + 3] == 0x01)
             {
                 secondOffset = i;
                 break;
@@ -355,9 +355,9 @@ public partial class Device
             int expectedOffset = (int)(firstOffset + stride * sectorNum);
             if(expectedOffset + 3 >= buffer.Length) break;
 
-            if(buffer[expectedOffset] != 0x00 ||
-               buffer[expectedOffset + 1] != 0x03 ||
-               buffer[expectedOffset + 2] != 0x00)
+            if(buffer[expectedOffset + 1] != 0x03 ||
+               buffer[expectedOffset + 2] != 0x00 ||
+               (buffer[expectedOffset + 3] != 0x02 && buffer[expectedOffset + 3] != 0x03))
             {
                 return 0; // Verification failed
             }
@@ -571,7 +571,7 @@ public partial class Device
 
         byte[] deinterleaved = DeinterleaveEccBlock(buffer, transferLength, _detectedBufferStride, _bufferFormat);
 
-        if(!CheckSectorNumber(deinterleaved, lba, transferLength, layerbreak, true))
+        if(!CheckSectorNumber(deinterleaved, lba, transferLength, layerbreak, otp))
         {
             // Buffer offset lost - this means we've wrapped around
             // Use the number of sectors read to detect buffer capacity


### PR DESCRIPTION
PTP discs were not handled correctly with 3c.

* PTP does not have to have layerbreak address, so use DataAreaEnd if layerbreak is 0.

> Byte 13 to 15 shall be set to (00) on SL disks and DL disks in PTP mode, and to the Sector Number of the last
Physical Sector of Layer 0 on DL disks in OTP mode. 

* Fix and use IsCorrectDlPtpPsn if disc is PTP.

* Make search pattern the PSN as there can be non-zero data in first sector byte.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.