### PR TITLE
Improve UDIF extraction by avoiding repeated and unnecessary enumeration

### DIFF
--- a/Aaru.Images/UDIF/Read.cs
+++ b/Aaru.Images/UDIF/Read.cs
@@ -420,6 +420,7 @@ public sealed partial class Udif
             }
         }
 
+        _chunkStartSectors     = _chunks.Keys.ToHashSet();
         _sectorCache           = new Dictionary<ulong, byte[]>();
         _chunkCache            = new Dictionary<ulong, byte[]>();
         _currentChunkCacheSize = 0;
@@ -459,11 +460,13 @@ public sealed partial class Udif
         var   chunkFound       = false;
         ulong chunkStartSector = 0;
 
-        foreach(KeyValuePair<ulong, BlockChunk> kvp in _chunks.Where(kvp => sectorAddress >= kvp.Key))
+        ulong chunkAddress = _chunkStartSectors.Last(chunkAd => sectorAddress >= chunkAd);
+
+        if(_chunks.TryGetValue(chunkAddress, out var value))
         {
-            readChunk        = kvp.Value;
+            readChunk        = value;
             chunkFound       = true;
-            chunkStartSector = kvp.Key;
+            chunkStartSector = chunkAddress;
         }
 
         long relOff = ((long)sectorAddress - (long)chunkStartSector) * SECTOR_SIZE;

--- a/Aaru.Images/UDIF/UDIF.cs
+++ b/Aaru.Images/UDIF/UDIF.cs
@@ -48,6 +48,7 @@ public sealed partial class Udif : IWritableImage
     uint                          _buffersize;
     Dictionary<ulong, byte[]>     _chunkCache;
     Dictionary<ulong, BlockChunk> _chunks;
+    HashSet<ulong>                _chunkStartSectors;
     BlockChunk                    _currentChunk;
     uint                          _currentChunkCacheSize;
     ulong                         _currentSector;


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I'm not sure which of the above this would tick, sorry.

This uses your suggested improvements to a particularly slow piece of UDIF archive reading. This greatly improves the speed and performance of extracting UDIF archives, while (ideally) maintaining algorithmic compatibility. This has not been extensively tested, although I'm not sure what it would break, and it seems to work fine.