### PR TITLE
Return blocksToRead if omnidrive and not nintendo disc

### DIFF
--- a/Aaru.Core/Devices/ReaderSCSI.cs
+++ b/Aaru.Core/Devices/ReaderSCSI.cs
@@ -592,7 +592,13 @@ sealed partial class Reader
                 if(_dev.IsOmniDriveFirmware())
                 {
                     bool omniStandardOk = !_dev.OmniDriveReadRawDvd(out _, out senseBuf, 0, 1, _timeout, out _, true, true);
-                    bool omniNintendoOk = !_dev.OmniDriveReadNintendoDvd(out _,
+                    if(omniStandardOk)
+                    {
+                        OmniDriveReadRaw = true;
+                    }
+                    else
+                    {
+                        OmniDriveReadRaw = !_dev.OmniDriveReadNintendoDvd(out _,
                                                                           out senseBuf,
                                                                           0,
                                                                           1,
@@ -603,7 +609,7 @@ sealed partial class Reader
                                                                           null,
                                                                           false,
                                                                           0);
-                    OmniDriveReadRaw    = omniStandardOk || omniNintendoOk;
+                    }
                 }
 
                 if(HldtstReadRaw || _plextorReadRaw || ReadBuffer3CReadRaw || OmniDriveReadRaw)
@@ -709,7 +715,10 @@ sealed partial class Reader
             if(HldtstReadRaw || ReadBuffer3CReadRaw)
                 BlocksToRead = 1;
             else if(OmniDriveReadRaw)
+            {
                 BlocksToRead = (uint)Math.Min(31, startWithBlocks);
+                return false;
+            }
             else if(_read6)
             {
                 _dev.Read6(out _, out _, 0, LogicalBlockSize, (byte)BlocksToRead, _timeout, out _);

--- a/Aaru.Core/Devices/ReaderSCSI.cs
+++ b/Aaru.Core/Devices/ReaderSCSI.cs
@@ -592,24 +592,20 @@ sealed partial class Reader
                 if(_dev.IsOmniDriveFirmware())
                 {
                     bool omniStandardOk = !_dev.OmniDriveReadRawDvd(out _, out senseBuf, 0, 1, _timeout, out _, true, true);
-                    if(omniStandardOk)
-                    {
-                        OmniDriveReadRaw = true;
-                    }
-                    else
-                    {
-                        OmniDriveReadRaw = !_dev.OmniDriveReadNintendoDvd(out _,
-                                                                          out senseBuf,
-                                                                          0,
-                                                                          1,
-                                                                          _timeout,
-                                                                          out _,
-                                                                          true,
-                                                                          true,
-                                                                          null,
-                                                                          false,
-                                                                          0);
-                    }
+
+                    OmniDriveReadRaw = omniStandardOk
+                                           ? true
+                                           : !_dev.OmniDriveReadNintendoDvd(out _,
+                                                                            out senseBuf,
+                                                                            0,
+                                                                            1,
+                                                                            _timeout,
+                                                                            out _,
+                                                                            true,
+                                                                            true,
+                                                                            null,
+                                                                            false,
+                                                                            0);
                 }
 
                 if(HldtstReadRaw || _plextorReadRaw || ReadBuffer3CReadRaw || OmniDriveReadRaw)


### PR DESCRIPTION
## Types of changes

I managed to break regular disc reads with omnidrive when adding nintendo support. This should fix that.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.