### PR TITLE
Ask for consent before initialising crash reporting

### DIFF
--- a/Aaru.Gui/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/Aaru.Gui/ViewModels/Dialogs/SettingsViewModel.cs
@@ -64,6 +64,8 @@ public sealed partial class SettingsViewModel : ViewModelBase
     [ObservableProperty]
     bool _saveStatsChecked;
     [ObservableProperty]
+    bool _shareCrashReportsChecked;
+    [ObservableProperty]
     bool _shareReportsChecked;
     [ObservableProperty]
     bool _shareStatsChecked;
@@ -78,6 +80,7 @@ public sealed partial class SettingsViewModel : ViewModelBase
         GdprVisible                = gdprChange;
         SaveReportsGloballyChecked = Settings.Settings.Current.SaveReportsGlobally;
         ShareReportsChecked        = Settings.Settings.Current.ShareReports;
+        ShareCrashReportsChecked   = Settings.Settings.Current.ShareCrashReports;
 
         if(Settings.Settings.Current.Stats != null)
         {
@@ -110,6 +113,7 @@ public sealed partial class SettingsViewModel : ViewModelBase
     {
         Settings.Settings.Current.SaveReportsGlobally = SaveReportsGloballyChecked;
         Settings.Settings.Current.ShareReports        = ShareReportsChecked;
+        Settings.Settings.Current.ShareCrashReports   = ShareCrashReportsChecked;
 
         if(SaveStatsChecked)
         {

--- a/Aaru.Gui/Views/Dialogs/SettingsDialog.xaml
+++ b/Aaru.Gui/Views/Dialogs/SettingsDialog.xaml
@@ -97,6 +97,13 @@
                                 <TextBlock Text="{x:Static localization:UI.Share_your_device_reports_with_us_Q}" />
                             </CheckBox>
                         </StackPanel>
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{x:Static localization:UI.Configure_crash_report_disclaimer}"
+                                       TextWrapping="Wrap" />
+                            <CheckBox IsChecked="{Binding ShareCrashReportsChecked, Mode=TwoWay}">
+                                <TextBlock Text="{x:Static localization:UI.Share_crash_reports_with_us_Q}" />
+                            </CheckBox>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/Aaru.Localization/UI.Designer.cs
+++ b/Aaru.Localization/UI.Designer.cs
@@ -3340,12 +3340,24 @@ namespace Aaru.Localization {
             }
         }
         
+        public static string Configure_crash_report_disclaimer {
+            get {
+                return ResourceManager.GetString("Configure_crash_report_disclaimer", resourceCulture);
+            }
+        }
+
         public static string Configure_share_report_disclaimer {
             get {
                 return ResourceManager.GetString("Configure_share_report_disclaimer", resourceCulture);
             }
         }
         
+        public static string Do_you_want_to_share_crash_reports_with_us_Q {
+            get {
+                return ResourceManager.GetString("Do_you_want_to_share_crash_reports_with_us_Q", resourceCulture);
+            }
+        }
+
         public static string Do_you_want_to_share_your_device_reports_with_us_Q {
             get {
                 return ResourceManager.GetString("Do_you_want_to_share_your_device_reports_with_us_Q", resourceCulture);
@@ -3754,6 +3766,12 @@ namespace Aaru.Localization {
             }
         }
         
+        public static string Share_crash_reports_with_us_Q {
+            get {
+                return ResourceManager.GetString("Share_crash_reports_with_us_Q", resourceCulture);
+            }
+        }
+
         public static string Share_your_device_reports_with_us_Q {
             get {
                 return ResourceManager.GetString("Share_your_device_reports_with_us_Q", resourceCulture);

--- a/Aaru.Localization/UI.es.resx
+++ b/Aaru.Localization/UI.es.resx
@@ -475,6 +475,9 @@
     <data name="Configure_enable_decryption_disclaimer" xml:space="preserve">
     <value>¿Desea activar la desencriptación de los medios protegidos contra copia (o DRM)? Por ejemplo la encriptación CSS de un DVD de video. Consulte sus leyes locales antes de activarla, ya que es ilegan en algunos países, o legal sólo en determinadas circunstancias.</value>
   </data>
+    <data name="Configure_crash_report_disclaimer" xml:space="preserve">
+    <value>Los informes de fallos se envían a nuestro propio servidor para que podamos encontrar y corregir los errores con los que se encuentre. Un informe contiene el error y su traza de pila, su sistema operativo, la versión de Aaru, la línea de órdenes que ejecutó y un identificador de instalación que permanece igual entre ejecuciones. En una herramienta de volcado de discos, una línea de órdenes nombra habitualmente rutas de dispositivos y de salida.</value>
+  </data>
     <data name="Configure_share_report_disclaimer" xml:space="preserve">
     <value>Compartir un reporte lo enviará a nuestro servidor, localizado en la Unión Europa, dónde será analizado manualmente por un ciudadano europeo para eliminar cualquier rastro de identificación personal del mismo. Una vez hecho, se compartirá en nuestra web de estadísticas: https://www.aaru.app Este reporte se usará para mejorar el soporte de Aaru, y en algunos casos, para proveer emulación de los dispositivos a otros projectos de código abierto. En cualquier caso, no se almacenará ninguna información que le vincule con el reporte.</value>
   </data>
@@ -885,6 +888,9 @@
   </data>
     <data name="Do_you_want_to_save_stats_about_your_Aaru_usage_Q" xml:space="preserve">
     <value>¿Desea guardar estadísticas acerca de su uso de Aaru?</value>
+  </data>
+    <data name="Do_you_want_to_share_crash_reports_with_us_Q" xml:space="preserve">
+    <value>¿Desea compartir los informes de fallos con nosotres?</value>
   </data>
     <data name="Do_you_want_to_share_your_device_reports_with_us_Q" xml:space="preserve">
     <value>¿Desea compartir sus reportes de dispositivo con nosotres?</value>
@@ -2065,6 +2071,9 @@
   </data>
     <data name="Setting_tracks_list" xml:space="preserve">
     <value>Estableciendo lista de pistas</value>
+  </data>
+    <data name="Share_crash_reports_with_us_Q" xml:space="preserve">
+    <value>Compartir los informes de fallos con nosotres</value>
   </data>
     <data name="Share_your_device_reports_with_us_Q" xml:space="preserve">
     <value>¿Compartir sus reportes de dispositivo con nosotres?</value>

--- a/Aaru.Localization/UI.resx
+++ b/Aaru.Localization/UI.resx
@@ -1702,12 +1702,21 @@ where Aaru is being run from.</value>
     <data name="Configure_Do_you_want_to_save_device_reports_in_shared_folder_of_your_computer_Q" xml:space="preserve">
     <value>Do you want to save device reports in shared folder of your computer?</value>
   </data>
+    <data name="Configure_crash_report_disclaimer" xml:space="preserve">
+    <value>Crash reports are sent to our own server so we can find and fix the errors you run into. A report
+contains the error and its stack trace, your operating system, the Aaru version, the command line you ran,
+and an installation identifier that stays the same between runs. On a disc imaging tool a command line
+routinely names device and output paths.</value>
+  </data>
     <data name="Configure_share_report_disclaimer" xml:space="preserve">
     <value>Sharing a report with us will send it to our server, that's in the european union territory, where it
 will be manually analyzed by an european union citizen to remove any trace of personal identification
 from it. Once that is done, it will be shared in our stats website, https://www.aaru.app
 These report will be used to improve Aaru support, and in some cases, to provide emulation of the
 devices to other open-source projects. In any case, no information linking the report to you will be stored.</value>
+  </data>
+    <data name="Do_you_want_to_share_crash_reports_with_us_Q" xml:space="preserve">
+    <value>Do you want to share crash reports with us?</value>
   </data>
     <data name="Do_you_want_to_share_your_device_reports_with_us_Q" xml:space="preserve">
     <value>Do you want to share your device reports with us?</value>
@@ -1930,6 +1939,9 @@ Testers:
   </data>
     <data name="Save_device_reports_in_shared_folder_of_your_computer_Q" xml:space="preserve">
     <value>Save device reports in shared folder of your computer?</value>
+  </data>
+    <data name="Share_crash_reports_with_us_Q" xml:space="preserve">
+    <value>Share crash reports with us</value>
   </data>
     <data name="Share_your_device_reports_with_us_Q" xml:space="preserve">
     <value>Share your device reports with us?</value>

--- a/Aaru.Settings/Settings.cs
+++ b/Aaru.Settings/Settings.cs
@@ -70,6 +70,8 @@ public class DicSettings
     public bool SaveReportsGlobally;
     /// <summary>If set to <c>true</c>, crash reports will be sent to the Aaru crash reporting server</summary>
     public bool ShareCrashReports;
+    /// <summary>If set to <c>true</c>, the user has already been asked whether to share crash reports</summary>
+    public bool HasConsentBeenAsked;
     /// <summary>If set to <c>true</c>, reports will be sent to Aaru.Server</summary>
     public bool ShareReports;
     /// <summary>Statistics</summary>
@@ -298,6 +300,9 @@ public static class Settings
                         Current.ShareCrashReports =
                             parsedPreferences.TryGetValue("ShareCrashReports", out obj) && ((NSNumber)obj).ToBool();
 
+                        Current.HasConsentBeenAsked =
+                            parsedPreferences.TryGetValue("HasConsentBeenAsked", out obj) && ((NSNumber)obj).ToBool();
+
                         Current.EnableDecryption = parsedPreferences.TryGetValue("EnableDecryption", out obj) &&
                                                    ((NSNumber)obj).ToBool();
 
@@ -378,6 +383,7 @@ public static class Settings
                         Current.SaveReportsGlobally = Convert.ToBoolean(dicKey.GetValue("SaveReportsGlobally"));
                         Current.ShareReports        = Convert.ToBoolean(dicKey.GetValue("ShareReports"));
                         Current.ShareCrashReports   = Convert.ToBoolean(dicKey.GetValue("ShareCrashReports"));
+                        Current.HasConsentBeenAsked = Convert.ToBoolean(dicKey.GetValue("HasConsentBeenAsked"));
                         Current.GdprCompliance      = Convert.ToUInt64(dicKey.GetValue("GdprCompliance"));
                         Current.EnableDecryption    = Convert.ToBoolean(dicKey.GetValue("EnableDecryption"));
 
@@ -418,6 +424,7 @@ public static class Settings
                     Current.SaveReportsGlobally = Convert.ToBoolean(key.GetValue("SaveReportsGlobally"));
                     Current.ShareReports        = Convert.ToBoolean(key.GetValue("ShareReports"));
                     Current.ShareCrashReports   = Convert.ToBoolean(key.GetValue("ShareCrashReports"));
+                    Current.HasConsentBeenAsked = Convert.ToBoolean(key.GetValue("HasConsentBeenAsked"));
                     Current.GdprCompliance      = Convert.ToUInt64(key.GetValue("GdprCompliance"));
                     Current.EnableDecryption    = Convert.ToBoolean(key.GetValue("EnableDecryption"));
 
@@ -543,6 +550,9 @@ public static class Settings
                             "ShareCrashReports", Current.ShareCrashReports
                         },
                         {
+                            "HasConsentBeenAsked", Current.HasConsentBeenAsked
+                        },
+                        {
                             "GdprCompliance", Current.GdprCompliance
                         },
                         {
@@ -621,6 +631,7 @@ public static class Settings
                         key.SetValue("SaveReportsGlobally", Current.SaveReportsGlobally);
                         key.SetValue("ShareReports",        Current.ShareReports);
                         key.SetValue("ShareCrashReports",   Current.ShareCrashReports);
+                        key.SetValue("HasConsentBeenAsked", Current.HasConsentBeenAsked);
                         key.SetValue("GdprCompliance",      Current.GdprCompliance);
                         key.SetValue("EnableDecryption",    Current.EnableDecryption);
 
@@ -692,6 +703,8 @@ public static class Settings
         // Unlike the other switches, this one is not gated by the configure wizard: crash reporting starts before
         // the wizard can run, so an opt-in default would send data from a user who was never asked.
         ShareCrashReports   = false,
+        // No consent decision has been recorded yet; the first interactive run asks and sets this.
+        HasConsentBeenAsked = false,
         GdprCompliance      = 0,
         EnableDecryption    = true,
         Stats = new StatsSettings

--- a/Aaru.Settings/Settings.cs
+++ b/Aaru.Settings/Settings.cs
@@ -68,6 +68,8 @@ public class DicSettings
 
     /// <summary>If set to <c>true</c>, reports will be saved locally</summary>
     public bool SaveReportsGlobally;
+    /// <summary>If set to <c>true</c>, crash reports will be sent to the Aaru crash reporting server</summary>
+    public bool ShareCrashReports;
     /// <summary>If set to <c>true</c>, reports will be sent to Aaru.Server</summary>
     public bool ShareReports;
     /// <summary>Statistics</summary>
@@ -293,6 +295,9 @@ public static class Settings
                         Current.ShareReports = parsedPreferences.TryGetValue("ShareReports", out obj) &&
                                                ((NSNumber)obj).ToBool();
 
+                        Current.ShareCrashReports =
+                            parsedPreferences.TryGetValue("ShareCrashReports", out obj) && ((NSNumber)obj).ToBool();
+
                         Current.EnableDecryption = parsedPreferences.TryGetValue("EnableDecryption", out obj) &&
                                                    ((NSNumber)obj).ToBool();
 
@@ -372,6 +377,7 @@ public static class Settings
                     {
                         Current.SaveReportsGlobally = Convert.ToBoolean(dicKey.GetValue("SaveReportsGlobally"));
                         Current.ShareReports        = Convert.ToBoolean(dicKey.GetValue("ShareReports"));
+                        Current.ShareCrashReports   = Convert.ToBoolean(dicKey.GetValue("ShareCrashReports"));
                         Current.GdprCompliance      = Convert.ToUInt64(dicKey.GetValue("GdprCompliance"));
                         Current.EnableDecryption    = Convert.ToBoolean(dicKey.GetValue("EnableDecryption"));
 
@@ -411,6 +417,7 @@ public static class Settings
 
                     Current.SaveReportsGlobally = Convert.ToBoolean(key.GetValue("SaveReportsGlobally"));
                     Current.ShareReports        = Convert.ToBoolean(key.GetValue("ShareReports"));
+                    Current.ShareCrashReports   = Convert.ToBoolean(key.GetValue("ShareCrashReports"));
                     Current.GdprCompliance      = Convert.ToUInt64(key.GetValue("GdprCompliance"));
                     Current.EnableDecryption    = Convert.ToBoolean(key.GetValue("EnableDecryption"));
 
@@ -533,6 +540,9 @@ public static class Settings
                             "ShareReports", Current.ShareReports
                         },
                         {
+                            "ShareCrashReports", Current.ShareCrashReports
+                        },
+                        {
                             "GdprCompliance", Current.GdprCompliance
                         },
                         {
@@ -610,6 +620,7 @@ public static class Settings
                     {
                         key.SetValue("SaveReportsGlobally", Current.SaveReportsGlobally);
                         key.SetValue("ShareReports",        Current.ShareReports);
+                        key.SetValue("ShareCrashReports",   Current.ShareCrashReports);
                         key.SetValue("GdprCompliance",      Current.GdprCompliance);
                         key.SetValue("EnableDecryption",    Current.EnableDecryption);
 
@@ -678,6 +689,9 @@ public static class Settings
     {
         SaveReportsGlobally = true,
         ShareReports        = true,
+        // Unlike the other switches, this one is not gated by the configure wizard: crash reporting starts before
+        // the wizard can run, so an opt-in default would send data from a user who was never asked.
+        ShareCrashReports   = false,
         GdprCompliance      = 0,
         EnableDecryption    = true,
         Stats = new StatsSettings

--- a/Aaru/Commands/Configure.cs
+++ b/Aaru/Commands/Configure.cs
@@ -89,6 +89,17 @@ sealed class ConfigureCommand : Command<ConfigureCommand.Settings>
 
 #endregion Device reports
 
+#region Crash reports
+
+        AaruLogging.WriteLine();
+
+        AaruLogging.WriteLine(UI.Configure_crash_report_disclaimer);
+
+        Aaru.Settings.Settings.Current.ShareCrashReports =
+            AnsiConsole.Confirm($"[italic]{UI.Do_you_want_to_share_crash_reports_with_us_Q}[/]");
+
+#endregion Crash reports
+
 #region Statistics
 
         AaruLogging.WriteLine();

--- a/Aaru/Commands/Configure.cs
+++ b/Aaru/Commands/Configure.cs
@@ -91,12 +91,7 @@ sealed class ConfigureCommand : Command<ConfigureCommand.Settings>
 
 #region Crash reports
 
-        AaruLogging.WriteLine();
-
-        AaruLogging.WriteLine(UI.Configure_crash_report_disclaimer);
-
-        Aaru.Settings.Settings.Current.ShareCrashReports =
-            AnsiConsole.Confirm($"[italic]{UI.Do_you_want_to_share_crash_reports_with_us_Q}[/]");
+        AskCrashReportConsent();
 
 #endregion Crash reports
 
@@ -142,6 +137,23 @@ sealed class ConfigureCommand : Command<ConfigureCommand.Settings>
         Aaru.Settings.Settings.SaveSettings();
 
         return (int)ErrorNumber.NoError;
+    }
+
+    /// <summary>Asks the user whether to share crash reports and records that the question has now been asked.</summary>
+    /// <remarks>
+    ///     Shared by the full <see cref="DoConfigure" /> wizard and by the one-off consent prompt at startup, so the
+    ///     wording and the flag live in a single place. The caller is responsible for persisting the settings.
+    /// </remarks>
+    internal void AskCrashReportConsent()
+    {
+        AaruLogging.WriteLine();
+
+        AaruLogging.WriteLine(UI.Configure_crash_report_disclaimer);
+
+        Aaru.Settings.Settings.Current.ShareCrashReports =
+            AnsiConsole.Confirm($"[italic]{UI.Do_you_want_to_share_crash_reports_with_us_Q}[/]");
+
+        Aaru.Settings.Settings.Current.HasConsentBeenAsked = true;
     }
 
 #region Nested type: Settings

--- a/Aaru/Main.cs
+++ b/Aaru/Main.cs
@@ -82,32 +82,6 @@ class MainClass
         if(args.Length == 1 && args[0].Equals("gui", StringComparison.InvariantCultureIgnoreCase))
             return Gui.Main.Start(args);
 
-        SentrySdk.Init(static options =>
-        {
-            // A Sentry Data Source Name (DSN) is required.
-            // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
-            // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
-            options.Dsn = "https://153a04fb97b78bb57a8013b8b30db04f@sentry.claunia.com/8";
-
-            // When debug is enabled, the Sentry client will emit detailed debugging information to the console.
-            // This might be helpful, or might interfere with the normal operation of your application.
-            // We enable it here for demonstration purposes when first trying Sentry.
-            // You shouldn't do this in your applications unless you're troubleshooting issues with Sentry.
-            //options.Debug = true;
-
-            // This option is recommended. It enables Sentry's "Release Health" feature.
-            options.AutoSessionTracking = true;
-
-            // Set TracesSampleRate to 1.0 to capture 100%
-            // of transactions for tracing.
-            // We recommend adjusting this value in production.
-            options.TracesSampleRate = 1.0;
-
-            options.IsGlobalModeEnabled = true;
-        });
-
-        SentrySdk.ConfigureScope(static scope => scope.SetExtra("Args", Environment.GetCommandLineArgs()));
-
         try
         {
             AaruLogging.WriteLineEvent += static (format, objects) =>
@@ -172,6 +146,32 @@ class MainClass
             AaruLogging.InformationEvent += Log.Information;
 
             Settings.Settings.LoadSettings();
+
+            // Crash reporting is opt-in, so it cannot start before the stored settings have been read. Anything
+            // that fails earlier than this goes unreported, because at that point we do not yet know if we may.
+            if(Settings.Settings.Current.ShareCrashReports)
+            {
+                SentrySdk.Init(static options =>
+                {
+                    // A Sentry Data Source Name (DSN) is required.
+                    // See https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+                    // You can set it in the SENTRY_DSN environment variable, or you can set it in code here.
+                    if(string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("SENTRY_DSN")))
+                        options.Dsn = "https://153a04fb97b78bb57a8013b8b30db04f@sentry.claunia.com/8";
+
+                    // This option is recommended. It enables Sentry's "Release Health" feature.
+                    options.AutoSessionTracking = true;
+
+                    // Set TracesSampleRate to 1.0 to capture 100%
+                    // of transactions for tracing.
+                    // We recommend adjusting this value in production.
+                    options.TracesSampleRate = 1.0;
+
+                    options.IsGlobalModeEnabled = true;
+                });
+
+                SentrySdk.ConfigureScope(static scope => scope.SetExtra("Args", Environment.GetCommandLineArgs()));
+            }
 
             AaruContext ctx = null;
 

--- a/Aaru/Main.cs
+++ b/Aaru/Main.cs
@@ -147,6 +147,24 @@ class MainClass
 
             Settings.Settings.LoadSettings();
 
+            // Ask an existing user for crash-report consent once, so an upgrade is not silently opted out. A new
+            // user (GDPR level below the current one) is asked by the configuration wizard further down, and an
+            // explicit `configure` run asks on its own, so skip both to avoid asking twice. Only prompt when stdin
+            // is a terminal: Spectre's Confirm throws "Failed to read input in non-interactive mode" otherwise,
+            // which would abort every scripted, piped or service run, and any tool driving Aaru. When we cannot
+            // ask, leave the flag unset so a later interactive run asks, and keep reporting off until then.
+            bool consentAskedElsewhere =
+                Settings.Settings.Current.GdprCompliance < DicSettings.GDPR_LEVEL ||
+                args.Length >= 1 && args[0].Equals("configure", StringComparison.InvariantCultureIgnoreCase);
+
+            if(!Settings.Settings.Current.HasConsentBeenAsked &&
+               !consentAskedElsewhere                        &&
+               !Console.IsInputRedirected)
+            {
+                new ConfigureCommand().AskCrashReportConsent();
+                Settings.Settings.SaveSettings();
+            }
+
             // Crash reporting is opt-in, so it cannot start before the stored settings have been read. Anything
             // that fails earlier than this goes unreported, because at that point we do not yet know if we may.
             if(Settings.Settings.Current.ShareCrashReports)


### PR DESCRIPTION
Fixes #949.

`SentrySdk.Init` ran unconditionally at `Main.cs:85`, before `LoadSettings` and long before the consent check, so a fresh install reported before it could ask anything. This follows the shape you asked for in the issue: a new setting, carried through the settings infrastructure, localized.

### What changed

- **`ShareCrashReports`** added to `DicSettings`, read and written in all three backends (plist, registry, JSON), with a `configure` question and a checkbox in the GUI's Reports tab.
- **`SentrySdk.Init` moved behind `Settings.LoadSettings()`** and gated on that setting.
- **`options.Dsn` is left unset when `SENTRY_DSN` is present**, so the comment already sitting above it becomes true.
- Strings added to `UI.resx` and `UI.es.resx` (machine-translated, as you allowed).

### Three decisions worth your eye

**The default is `false`, unlike the neighbouring switches.** `SetDefaultSettings` shares everything by default, which is safe for the others because `GdprCompliance = 0` makes the wizard ask before they matter. Crash reporting starts before the wizard can run, so an opt-in default would send data from a user who was never asked.

**`Init` sits right after `LoadSettings`, not after the consent check.** That keeps every existing `CaptureException` call site covered — including `Main.cs:196`, which has no local logging and would otherwise fall silent. The cost is that `LoadSettings`'s own two catch blocks can no longer report; that seems unavoidable, since at that point there is no way to know whether reporting is allowed.

**`GDPR_LEVEL` is deliberately *not* raised.** Raising it looked right — the constant documents itself for exactly this case — but it is not safe here, and I measured why: with `GDPR_LEVEL = 2`, an existing install (`GdprCompliance = 1`) running without a TTY enters `DoConfigure` and dies at `Configure.cs:71` with exit 12. That is the same crash this issue is about, and raising the level would have delivered it to every existing user on their next scripted run. Existing installs therefore keep crash reporting off until they opt in via `configure` or the GUI. Say the word if you would rather have the prompt and handle the non-interactive case separately.

### How this was tested

Same binary, same endpoint, same command (`aaru --version`); `SENTRY_DSN` pointed at a local sink. Only the stored settings differ:

| scenario | exit | bytes sent | wizard ran |
| --- | --- | --- | --- |
| existing install, `ShareCrashReports=false` | 0 | 0 | no |
| fresh install, never asked | 12 | 0 | yes |
| consent granted | 0 | 376 | no |

The last row is there on purpose: without it, "nothing arrived" would not distinguish a working gate from a broken test.

Row two keeps its exit 12: the configure wizard still throws without a TTY, which it did before this change as well. What changes is that the exception is no longer reported to Sentry before anyone consented — that exception was the payload quoted in the issue.

The GUI side was exercised in a Fedora 44 VM (KDE on Wayland): the dialog loaded the setting unchecked, a keyboard toggle checked it, and `Save` wrote `"ShareCrashReports": true` to `Aaru.json`. The dialog was then rendered again under `es_ES.UTF-8`; the surrounding buttons switch to *Guardar*/*Cancelar*, so the Spanish strings are really being used rather than falling back to English.

Resource keys were additionally resolved at runtime in both cultures, with a deliberately absent key as the control.

### Note on building

`devel` did not build here until I locally pinned `Microsoft.CodeAnalysis.CSharp` down from `5.3.0` to `5.0.0`. With 5.3.0, `Aaru.Generators.dll` references compiler `5.3.0.0` while the .NET 10.0.109 SDK runs `5.0.0.0`, so the generator is skipped (CS9057) and every `partial` `Register` fails with CS0535. That pin is not part of this PR — it is reverted — but it may be worth knowing that `Directory.Packages.props` currently needs a newer SDK than distributions ship.

*Prepared with AI assistance (Claude Opus 4.8) and reviewed before submission.*
