### PR TITLE
Write metadata JSON with LF line endings only

### DIFF
--- a/Aaru.CommonTypes/AaruMetadata/AaruMetadata.cs
+++ b/Aaru.CommonTypes/AaruMetadata/AaruMetadata.cs
@@ -46,7 +46,7 @@ using Schemas;
 
 namespace Aaru.CommonTypes.AaruMetadata;
 
-[JsonSourceGenerationOptions(WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSourceGenerationOptions(WriteIndented = true, NewLine = "\n", DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(MetadataJson))]
 
 // ReSharper disable once PartialTypeWithSinglePart


### PR DESCRIPTION
Write metadata JSON with LF line endings regardless of the OS. In beta 1 the file is written with CRLF on Windows (larger file size) but LF on Linux, because the JSON writer's newline defaults to Environment.NewLine since .NET 9.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [ ] New media image, test images in [url]
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.